### PR TITLE
Switch to HTTPS URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ OpenShift Go Cartridge
 
 Runs [Go](http://golang.org) on [OpenShift](https://openshift.redhat.com/app/login) using downloadable cartridge support.  To install to OpenShift from the CLI (you'll need version 1.9 or later of rhc), run:
 
-    rhc create-app mygo http://cartreflect-claytondev.rhcloud.com/reflect?github=smarterclayton/openshift-go-cart
+    rhc create-app mygo https://cartreflect-claytondev.rhcloud.com/reflect?github=smarterclayton/openshift-go-cart
 
 Once the app is created, you'll need to create and add a ".godir" file in your repo to tell the cartridge what the package of your Go code is.  A typical .godir file might contain:
 


### PR DESCRIPTION
This didn't work on my OpenShift Origin install until I changed the reflector URL to HTTPS:

First, the failure:

```
 ┌┤smerrill@lilliputian-resolution [Jun 16 16:08:31] ~
 └╼ rhc create-app mygo http://cartreflect-claytondev.rhcloud.com/reflect?github=smarterclayton/openshift-go-cart
The cartridge 'http://cartreflect-claytondev.rhcloud.com/reflect?github=smarterclayton/openshift-go-cart' will be downloaded and installed

Application Options
-------------------
  Namespace:  phase2
  Cartridges: http://cartreflect-claytondev.rhcloud.com/reflect?github=smarterclayton/openshift-go-cart
  Gear Size:  default
  Scaling:    no

Creating application 'mygo' ... Invalid cartridge, error downloading from url 'http://cartreflect-claytondev.rhcloud.com/reflect?github=smartercla
yton/openshift-go-cart'
```

And the the success with HTTPS:

```
 ┌┤smerrill@lilliputian-resolution:1 [Jun 16 16:09:32] ~
 └╼ rhc create-app mygo https://cartreflect-claytondev.rhcloud.com/reflect?github=smarterclayton/openshift-go-cart
The cartridge 'https://cartreflect-claytondev.rhcloud.com/reflect?github=smarterclayton/openshift-go-cart' will be downloaded and installed

Application Options
-------------------
  Namespace:  phase2
  Cartridges: https://cartreflect-claytondev.rhcloud.com/reflect?github=smarterclayton/openshift-go-cart
  Gear Size:  default
  Scaling:    no

Creating application 'mygo' ... done

Waiting for your DNS name to be available ... done

Downloading the application Git repository ...
Cloning into 'mygo'...
The authenticity of host 'mygo-phase2.openshiftorigin (192.168.0.181)' can't be established.
RSA key fingerprint is d7:5c:9d:f0:e9:ed:87:1c:32:3a:f0:36:e6:55:66:83.
Are you sure you want to continue connecting (yes/no)? yes
Warning: Permanently added 'mygo-phase2.openshiftorigin' (RSA) to the list of known hosts.

Your application code is now in 'mygo'
[snipped]
```
