### PR TITLE
Fix is_go_service_running()

### DIFF
--- a/bin/control
+++ b/bin/control
@@ -25,6 +25,12 @@ function status() {
 
 function start() {
     logf="$OPENSHIFT_GO_DIR/logs/go.log"
+
+    if is_go_service_running; then
+        echo "`date +"$FMT"`: Application '$OPENSHIFT_APP_NAME' is already running; skipping start()"
+        return 0
+    fi
+
     pushd "$OPENSHIFT_REPO_DIR" > /dev/null
     {
         godir=$(cat .godir)
@@ -59,7 +65,7 @@ function stop() {
         echo "`date +"$FMT"`: Stopping application '$OPENSHIFT_APP_NAME' ..." >> $logf
         /bin/kill $go_pid
         ret=$?
-        if [ $ret -eq 0 ]; then
+        if [ $ret -ne 0 ]; then
             TIMEOUT="$STOPTIMEOUT"
             while [ $TIMEOUT -gt 0 ] && is_go_service_running ; do
                 /bin/kill -0 "$go_pid" >/dev/null 2>&1 || break


### PR DESCRIPTION
Because of the backticks, the if-block will fail 
because "PID" in the ps output is not a command.
