### PR TITLE
Upgraded to go 1.2.1 version

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ OpenShift Go Cartridge
 
 Runs [Go](http://golang.org) on [OpenShift](https://openshift.redhat.com/app/login) using downloadable cartridge support.  To install to OpenShift from the CLI (you'll need version 1.9 or later of rhc), run:
 
-    rhc create-app mygo https://cartreflect-claytondev.rhcloud.com/reflect?github=smarterclayton/openshift-go-cart
+    rhc create-app mygo https://cartreflect-claytondev.rhcloud.com/reflect?github=anidotnet/openshift-go-cart
 
 Once the app is created, you'll need to create and add a ".godir" file in your repo to tell the cartridge what the package of your Go code is.  A typical .godir file might contain:
 

--- a/bin/compile
+++ b/bin/compile
@@ -11,7 +11,7 @@ source "${OPENSHIFT_GO_DIR}/lib/util"
 mkdir -p "$1" "$2"
 build=$(cd "$1/" && pwd)
 cache=$(cd "$2/" && pwd)
-ver=${GOVERSION:-1.1.2}
+ver=${GOVERSION:-1.2.1}
 file=${GOFILE:-go$ver.$(uname|tr A-Z a-z)-amd64.tar.gz}
 url=${GOURL:-http://go.googlecode.com/files/$file}
 buildpack=$(dirname $(dirname $0))

--- a/metadata/manifest.yml
+++ b/metadata/manifest.yml
@@ -1,18 +1,19 @@
 Name: go
 Cartridge-Short-Name: GO
-Display-Name: Go 1.1.2
-Version: "1.1.2"
-Versions: ["1.1.2", "1.0.3"]
-Website: https://github.com/smarterclayton/openshift-go-cart
-Cartridge-Version: 0.0.1
+Display-Name: Go 1.2.1
+Version: "1.2.1"
+Versions: ["1.2.1", "1.1.2", "1.0.3"]
+Website: https://github.com/anidotnet/openshift-go-cart
+Cartridge-Version: 0.0.2
 Cartridge-Vendor: smarterclayton
 Categories:
   - service
   - golang
   - web_framework
 Provides:
-  - go-1.1
+  - go-1.2
   - "go"
+  - "go (version) = 1.2.1"
   - "go (version) = 1.1.2"
   - "go (version) = 1.1"
   - "go (version) = 1"
@@ -41,7 +42,7 @@ Subscribes:
     Required : false
 Group-Overrides:
   - components:
-    - go-1.1
+    - go-1.2
     - web_proxy
 Endpoints:
   - Private-IP-Name:   IP
@@ -57,15 +58,16 @@ Endpoints:
         Options:       { health: true }
 Install-Build-Required: true
 Version-Overrides:
-  '1.0.3':
-     Display-Name: Go 1.0.3
+  '1.2.1':
+     Display-Name: Go 1.2.1
      Provides:
-      - go-1.0
+      - go-1.2
       - "go"
+      - "go (version) = 1.2.1"
       - "go (version) = 1.0.3"
       - "go (version) = 1.0"
       - "go (version) = 1"
      Group-Overrides:
        - components:
-         - go-1.0
+         - go-1.2
          - web_proxy


### PR DESCRIPTION
If merged with the master, please change the below lines [replace string **anidotnet**]:

rhc create-app mygo https://cartreflect-claytondev.rhcloud.com/reflect?github=anidotnet/openshift-go-cart in README.md

&

Website: https://github.com/anidotnet/openshift-go-cart in metadata/manifest.yml
