### PR TITLE
Upgrade to Go 1.5.1

### DIFF
--- a/metadata/manifest.yml
+++ b/metadata/manifest.yml
@@ -1,8 +1,8 @@
 Name: go
 Cartridge-Short-Name: GO
-Display-Name: Go 1.4.2
-Version: "1.4.2"
-Versions: ["1.4.2","1.4.1", "1.4", "1.3.1","1.2.2","1.1.2", "1.0.3"]
+Display-Name: Go 1.5.1
+Version: "1.5.1"
+Versions: ["1.5.1","1.4.2","1.4.1", "1.4", "1.3.1","1.2.2","1.1.2", "1.0.3"]
 Website: https://github.com/smarterclayton/openshift-go-cart
 Cartridge-Version: 0.0.1
 Cartridge-Vendor: smarterclayton
@@ -11,7 +11,7 @@ Categories:
   - golang
   - web_framework
 Provides:
-  - go-1.4.2
+  - go-1.5.1
   - "go"
   - "go (version) = 1.2.2"
   - "go (version) = 1.1.2"

--- a/metadata/manifest.yml
+++ b/metadata/manifest.yml
@@ -1,8 +1,8 @@
 Name: go
 Cartridge-Short-Name: GO
-Display-Name: Go 1.5.1
-Version: "1.5.1"
-Versions: ["1.5.1","1.4.2","1.4.1", "1.4", "1.3.1","1.2.2","1.1.2", "1.0.3"]
+Display-Name: Go 1.6
+Version: "1.6"
+Versions: ["1.6", "1.5.1","1.4.2","1.4.1", "1.4", "1.3.1","1.2.2","1.1.2", "1.0.3"]
 Website: https://github.com/smarterclayton/openshift-go-cart
 Cartridge-Version: 0.0.1
 Cartridge-Vendor: smarterclayton
@@ -11,7 +11,7 @@ Categories:
   - golang
   - web_framework
 Provides:
-  - go-1.5.1
+  - go-1.6
   - "go"
   - "go (version) = 1.2.2"
   - "go (version) = 1.1.2"

--- a/metadata/manifest.yml
+++ b/metadata/manifest.yml
@@ -1,8 +1,8 @@
 Name: go
 Cartridge-Short-Name: GO
-Display-Name: Go 1.6
-Version: "1.6"
-Versions: ["1.6", "1.5.1","1.4.2","1.4.1", "1.4", "1.3.1","1.2.2","1.1.2", "1.0.3"]
+Display-Name: Go 1.7
+Version: "1.7"
+Versions: ["1.7", "1.6.3", "1.5.1","1.4.2","1.4.1", "1.4", "1.3.1","1.2.2","1.1.2", "1.0.3"]
 Website: https://github.com/smarterclayton/openshift-go-cart
 Cartridge-Version: 0.0.1
 Cartridge-Vendor: smarterclayton
@@ -11,7 +11,7 @@ Categories:
   - golang
   - web_framework
 Provides:
-  - go-1.6
+  - go-1.7
   - "go"
   - "go (version) = 1.2.2"
   - "go (version) = 1.1.2"


### PR DESCRIPTION
The go1.5.1 branch in github.com/golang/go is ready, and the official release is coming in soon time.
And https://storage.googleapis.com/golang/go1.5.1.linux-amd64.tar.gz is downloadable now, we could upgrade to Go 1.5.1 
